### PR TITLE
Add nixos-anywhere bootstrap docs for agenix and stable user IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,32 @@ nix run github:nix-community/nixos-anywhere -- \
   --build-on remote
 ```
 
-When the target host needs agenix-encrypted secrets during bootstrap:
+This repo expects the Home Manager agenix identity at `~/.ssh/agenix` on first boot. `nixos-anywhere --extra-files` copies a local directory tree into the installed system root, so provide the key under `home/joseph/.ssh/agenix` in a temporary directory and set the final ownership numerically:
+
+```bash
+temp="$(mktemp -d)"
+trap 'rm -rf "$temp"' EXIT
+
+install -d -m 700 "$temp/home/joseph/.ssh"
+install -m 600 ~/.ssh/agenix "$temp/home/joseph/.ssh/agenix"
+
+nix run github:nix-community/nixos-anywhere -- \
+  --flake .#<host> \
+  --target-host nixos@<ip-or-hostname> \
+  --build-on remote \
+  --extra-files "$temp" \
+  --chown /home/joseph/.ssh 1000:100
+```
+
+The numeric `1000:100` matches the hard-coded `joseph` UID and primary `users` group GID in this flake, so the ownership is correct even before the user account exists on the target system.
+
+When the target host also needs system agenix secrets during bootstrap:
 
 - add the host SSH key to `keys/`
 - update the relevant `secrets.nix` recipients
 - **rekey with `agenix -r`**
-- use `--copy-host-keys` when the install flow depends on preserving the generated host identity for secret decryption
+- use `--copy-host-keys` when the install flow depends on preserving an existing `/etc/ssh/ssh_host_*` identity for secret decryption
+- use `--extra-files` to seed `/etc/ssh/ssh_host_*` on brand-new machines when there is no existing host key to preserve
 
 ## Secrets
 

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,8 @@
 
       commonHostSpec = {
         username = "joseph";
+        uid = 1000;
+        gid = 100;
         userFullName = "Joseph Stahl";
         passwordFile = ./secrets/users/joseph.age;
         tailnet = "taildbd4c.ts.net";

--- a/hosts/common/users.nix
+++ b/hosts/common/users.nix
@@ -24,6 +24,7 @@ in
         ;
     }
     // lib.optionalAttrs isLinux {
+      group = "users";
       isNormalUser = true;
       createHome = true;
       linger = true;

--- a/modules/common/host-spec.nix
+++ b/modules/common/host-spec.nix
@@ -23,6 +23,12 @@
       description = "The UID for the host's primary user";
     };
 
+    gid = lib.mkOption {
+      type = lib.types.int;
+      default = config.hostSpec.uid;
+      description = "The GID for the host's primary user group";
+    };
+
     userFullName = lib.mkOption {
       type = lib.types.str;
       description = "The full name of the user";


### PR DESCRIPTION
## Summary
- Document how to bootstrap `~/.ssh/agenix` at install time with `nixos-anywhere --extra-files`.
- Clarify ownership and mode handling for the injected key so Home Manager can decrypt on first boot.
- Make `joseph`’s UID/GID stable in host metadata and use the `users` primary group on NixOS.

## Testing
- `nix eval --json .#nixosConfigurations.anacreon.config.users.users.joseph.uid`
- `nix eval --json .#nixosConfigurations.anacreon.config.users.users.joseph.group`
- `nix eval --json .#nixosConfigurations.anacreon.config.users.groups.users.gid`
- Not run (not requested)