### PR TITLE
Remove stale overlay note and fix backrest comment

### DIFF
--- a/hosts/nixos/anacreon/services/backrest.nix
+++ b/hosts/nixos/anacreon/services/backrest.nix
@@ -14,7 +14,7 @@ in
       bindAddress = "127.0.0.1";
     };
     caddy.virtualHosts."backrest.${domain}" = {
-      # TODO: multihost with HTTPS doesn't actually work right now, will re-evaluate after 1.31.1 is released (https://github.com/garethgeorge/backrest/pull/1219)
+      # TODO: multihost with HTTPS doesn't actually work right now, will re-evaluate after 1.13.1 is released (https://github.com/garethgeorge/backrest/pull/1219)
       # may need https://github.com/garethgeorge/backrest/commit/d6415931422cb0fb3bd6d14fbe11c37bd97ccf1b to work properly
       extraConfig = ''
         @sync path /v1sync.BackrestSyncService/*

--- a/overlays/modifications.nix
+++ b/overlays/modifications.nix
@@ -8,18 +8,4 @@ final: prev: {
       smartrent = callPackage ../pkgsLinux/homeassistant-customcomponents/smartrent/package.nix { };
     };
 
-  # zwave-js-server = prev.zwave-js-server.overrideAttrs (
-  #   _: old: rec {
-  #     version = "3.2.1";
-  #     src = old.src.override {
-  #       rev = version;
-  #       hash = "sha256-oZA+tMYxiWc+PiPiqGEJpEa434CqNjPbutBWjXBgmhw=";
-  #     };
-  #     npmDeps = final.fetchNpmDeps {
-  #       inherit src;
-  #       hash = "sha256-1JgfXF3kNuUj0jprKBsJSPeFH6ZpqpU4lceTQm5FBgg=";
-  #     };
-  #   }
-  # );
-
 }


### PR DESCRIPTION
## Summary
- Fix the Backrest TODO comment to reference the correct release version
- Remove the commented-out `zwave-js-server` override stub from overlays

## Testing
- Not run (not requested)