### PR TITLE
refactor(nixos): centralize storage and service dependencies

### DIFF
--- a/hosts/nixos/anacreon/services/tailscale-serve.nix
+++ b/hosts/nixos/anacreon/services/tailscale-serve.nix
@@ -6,22 +6,10 @@
 let
   tailscale = lib.getExe config.services.tailscale.package;
   routes = {
-    backrest = {
-      backend = "http://127.0.0.1:9898";
-      after = [ "backrest.service" ];
-    };
-    copyparty = {
-      backend = "http://127.0.0.1:3923";
-      after = [ "copyparty.service" ];
-    };
-    home = {
-      backend = "http://127.0.0.1:8080";
-      after = [ "caddy.service" ];
-    };
-    paperless = {
-      backend = "http://127.0.0.1:${toString config.services.paperless.port}";
-      after = [ "paperless.service" ];
-    };
+    backrest = "http://127.0.0.1:9898";
+    copyparty = "http://127.0.0.1:3923";
+    home = "http://127.0.0.1:8080";
+    paperless = "http://127.0.0.1:${toString config.services.paperless.port}";
   };
   tailscaleUnits = [
     "tailscaled.service"
@@ -30,11 +18,11 @@ let
   ];
 
   mkServeUnit =
-    serviceName: route:
+    serviceName: backend:
     lib.nameValuePair "anacreon-${serviceName}-tailscale-serve" {
       description = "Tailscale Serve proxy for Anacreon ${serviceName}";
-      after = route.after ++ tailscaleUnits;
-      wants = [ "tailscaled.service" ];
+      after = tailscaleUnits;
+      wants = tailscaleUnits;
       wantedBy = [ "multi-user.target" ];
 
       # Retry indefinitely if the daemon is running but tailnet authentication
@@ -50,7 +38,7 @@ let
           "serve"
           "--service=svc:${serviceName}"
           "--https=443"
-          route.backend
+          backend
         ];
         ExecStop = lib.escapeShellArgs [
           tailscale

--- a/hosts/nixos/terminus/default.nix
+++ b/hosts/nixos/terminus/default.nix
@@ -19,6 +19,7 @@
     ./disko.nix
     ./disko-hdd-storage.nix # separate from other disko config to allow for adding drive w/o formatting existing drives
     ./networking.nix
+    ./storage.nix
 
     # mixins
     ../common/mixins/tailscale.nix

--- a/hosts/nixos/terminus/networking.nix
+++ b/hosts/nixos/terminus/networking.nix
@@ -42,10 +42,5 @@ _: {
       publish.enable = true;
       publish.userServices = true;
     };
-    tailscale = {
-      extraUpFlags = [
-        "--advertise-exit-node"
-      ];
-    };
   };
 }

--- a/hosts/nixos/terminus/services/copyparty.nix
+++ b/hosts/nixos/terminus/services/copyparty.nix
@@ -8,14 +8,6 @@ in
     owner = "copyparty";
   };
 
-  systemd.services.copyparty = {
-    bindsTo = [ "storage.mount" ];
-    after = [
-      "storage.mount"
-      "storage-media.mount"
-    ];
-  };
-
   services.copyparty = {
     enable = true;
     settings = {

--- a/hosts/nixos/terminus/services/home-assistant/default.nix
+++ b/hosts/nixos/terminus/services/home-assistant/default.nix
@@ -125,8 +125,8 @@ in
     useACMEHost = domain;
   };
 
-  services.caddy.virtualHosts."home.${config.networking.domain}.${config.hostSpec.tailnet}" =
-    lib.mkIf config.services.home-assistant.enable
+  services.caddy.virtualHosts."home.${config.hostSpec.tailnet}" =
+    lib.mkIf (config.services.home-assistant.enable && config.hostSpec.tailnet != null)
       {
         extraConfig = ''
           reverse_proxy http://localhost:8123

--- a/hosts/nixos/terminus/services/home-assistant/zigbee.nix
+++ b/hosts/nixos/terminus/services/home-assistant/zigbee.nix
@@ -45,8 +45,10 @@ in
       };
     };
   };
-  systemd.services."zigbee2mqtt.service".requires = [ "mosquitto.service" ];
-  systemd.services."zigbee2mqtt.service".after = [ "mosquitto.service" ];
+  systemd.services.zigbee2mqtt = {
+    requires = [ "mosquitto.service" ];
+    after = [ "mosquitto.service" ];
+  };
 
   services.caddy.virtualHosts."zigbee.${domain}" = {
     extraConfig = ''

--- a/hosts/nixos/terminus/services/restic-server.nix
+++ b/hosts/nixos/terminus/services/restic-server.nix
@@ -11,11 +11,6 @@ in
     extraFlags = [ "--no-auth" ]; # auth managed by tailscale
   };
 
-  systemd.services.restic-rest-server = {
-    bindsTo = [ "storage-restic.mount" ];
-    after = [ "storage-restic.mount" ];
-  };
-
   services.caddy.virtualHosts = lib.mkIf config.services.restic.server.enable {
     "restic.${domain}" = {
       extraConfig = ''

--- a/hosts/nixos/terminus/services/restic/copy-to-s3.nix
+++ b/hosts/nixos/terminus/services/restic/copy-to-s3.nix
@@ -26,6 +26,11 @@ in
     rcloneCommand = "copy";
     environmentFile = config.age.secrets.rclone-sync.path;
     rcloneConfFile = config.age.secrets.rcloneConf.path;
+    extraRcloneArgs = [
+      "--transfers=32"
+      "--b2-hard-delete"
+      "--fast-list"
+    ];
 
     timerConfig = {
       OnCalendar = "06:00";

--- a/hosts/nixos/terminus/services/restic/system-backup.nix
+++ b/hosts/nixos/terminus/services/restic/system-backup.nix
@@ -45,4 +45,9 @@ in
       RandomizedDelaySec = "1h";
     };
   };
+
+  systemd.services.restic-backups-system-backup = {
+    requires = [ "restic-rest-server.socket" ];
+    after = [ "restic-rest-server.socket" ];
+  };
 }

--- a/hosts/nixos/terminus/services/samba.nix
+++ b/hosts/nixos/terminus/services/samba.nix
@@ -9,7 +9,6 @@
     file = ../secrets/smbpasswd.age;
   };
 
-  users.groups.media = { };
   # create "samba-guest:media" user for accessing shares
   users.users."samba-guest" = {
     isSystemUser = true; # not a normal user account
@@ -27,8 +26,7 @@
   # https://www.samba.org/samba/docs/current/man-html/pdbedit.8.html
   systemd.services.samba-setup = {
     description = "Import Samba passwords";
-    wantedBy = [ "smbd.service" ];
-    before = [ "smbd.service" ];
+    before = [ "samba-smbd.service" ];
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
@@ -43,13 +41,6 @@
   # tmpfiles to create shares if not yet present
   systemd.tmpfiles.settings = {
     "10-samba-shares" = {
-      "/storage/media" = {
-        d = {
-          user = "samba-guest";
-          group = "media";
-          mode = "0775";
-        };
-      };
       "/storage/homes/public" = {
         d = {
           user = "samba-guest";
@@ -98,6 +89,7 @@
       media = {
         path = "/storage/media";
         "guest ok" = "yes";
+        "inherit permissions" = "yes";
         "public" = "yes";
         "write list" = "joseph";
         "force group" = "media";

--- a/hosts/nixos/terminus/services/servarr/default.nix
+++ b/hosts/nixos/terminus/services/servarr/default.nix
@@ -8,7 +8,4 @@
     ./sonarr.nix
     ./recyclarr.nix
   ];
-
-  # Create the group for media stuff (jellyfin, sabnzbd, etc)
-  users.groups.media = { };
 }

--- a/hosts/nixos/terminus/services/servarr/jellyfin.nix
+++ b/hosts/nixos/terminus/services/servarr/jellyfin.nix
@@ -10,12 +10,6 @@ in
 
   users.users.jellyfin.extraGroups = [ "render" ];
 
-  systemd.services.jellyfin = {
-    requires = [ "storage-media.mount" ]; # requires, instead of bindsTo - can keep jellyfin running even
-    # if storage is lost
-    after = [ "storage-media.mount" ];
-  };
-
   services.caddy.virtualHosts."jellyfin.${domain}" = {
     extraConfig = ''
       reverse_proxy http://localhost:8096

--- a/hosts/nixos/terminus/services/servarr/radarr.nix
+++ b/hosts/nixos/terminus/services/servarr/radarr.nix
@@ -17,11 +17,6 @@ in
     };
   };
 
-  systemd.services.radarr = {
-    bindsTo = [ "storage-media.mount" ];
-    after = [ "storage-media.mount" ];
-  };
-
   services.caddy.virtualHosts."radarr.${domain}" = {
     extraConfig = ''
       reverse_proxy http://localhost:7878

--- a/hosts/nixos/terminus/services/servarr/recyclarr.nix
+++ b/hosts/nixos/terminus/services/servarr/recyclarr.nix
@@ -92,4 +92,15 @@
       };
     };
   };
+
+  systemd.services.recyclarr = {
+    requires = [
+      "radarr.service"
+      "sonarr.service"
+    ];
+    after = [
+      "radarr.service"
+      "sonarr.service"
+    ];
+  };
 }

--- a/hosts/nixos/terminus/services/servarr/sabnzbd.nix
+++ b/hosts/nixos/terminus/services/servarr/sabnzbd.nix
@@ -17,14 +17,9 @@ in
         host_whitelist = "${config.networking.hostName},sabnzbd.${domain}";
         download_dir = "/storage/media/usenet/incomplete";
         complete_dir = "/storage/media/usenet/complete";
-        permissions = "775";
+        permissions = "2775";
       };
     };
-  };
-
-  systemd.services.sabnzbd = {
-    bindsTo = [ "storage.mount" ];
-    after = [ "storage.mount" ];
   };
 
   services.restic.backups.system-backup.paths = [
@@ -51,15 +46,4 @@ in
     useACMEHost = domain;
   };
 
-  systemd.tmpfiles.settings = {
-    "10-sabnzbd" = {
-      "/storage/media/usenet" = {
-        d = {
-          user = "sabnzbd";
-          group = "media";
-          mode = "0770";
-        };
-      };
-    };
-  };
 }

--- a/hosts/nixos/terminus/services/servarr/sonarr.nix
+++ b/hosts/nixos/terminus/services/servarr/sonarr.nix
@@ -17,11 +17,6 @@ in
     };
   };
 
-  systemd.services.sonarr = {
-    bindsTo = [ "storage-media.mount" ];
-    after = [ "storage-media.mount" ];
-  };
-
   services.caddy.virtualHosts."sonarr.${domain}" = {
     extraConfig = ''
       reverse_proxy http://localhost:8989

--- a/hosts/nixos/terminus/storage.nix
+++ b/hosts/nixos/terminus/storage.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  utils,
+  ...
+}:
+let
+  mountUnit = path: "${utils.escapeSystemdPath path}.mount";
+  homesMount = mountUnit "/storage/homes";
+  mediaMount = mountUnit "/storage/media";
+  resticMount = mountUnit "/storage/restic";
+  storageMount = mountUnit "/storage";
+in
+{
+  # Shared ownership for services that read from or write to media storage.
+  users.groups.media = { };
+
+  # New directories inherit the media group. Cooperative service umasks keep
+  # files and directories writable by the other media services.
+  systemd.tmpfiles.settings."10-media" = {
+    "/storage/media".d = {
+      user = "root";
+      group = "media";
+      mode = "2775";
+    };
+    "/storage/media/usenet".d = {
+      user = "sabnzbd";
+      group = "media";
+      mode = "2775";
+    };
+  };
+
+  systemd.services = {
+    backrest = {
+      bindsTo = [ storageMount ];
+      unitConfig.RequiresMountsFor = [ "/storage" ];
+    };
+
+    copyparty = {
+      bindsTo = [
+        storageMount
+        mediaMount
+      ];
+      unitConfig.RequiresMountsFor = [ "/storage/media" ];
+    };
+
+    jellyfin.unitConfig = {
+      WantsMountsFor = [ "/storage/media" ];
+      AssertPathIsMountPoint = [ "/storage/media" ];
+    };
+
+    radarr = {
+      bindsTo = [ mediaMount ];
+      unitConfig.RequiresMountsFor = [ "/storage/media" ];
+      serviceConfig.UMask = lib.mkForce "0002";
+    };
+
+    rclone-sync-b2.bindsTo = [ resticMount ];
+
+    restic-rest-server = {
+      bindsTo = [ resticMount ];
+      unitConfig.RequiresMountsFor = [ "/storage/restic" ];
+    };
+
+    sabnzbd = {
+      bindsTo = [ mediaMount ];
+      unitConfig.RequiresMountsFor = [ "/storage/media" ];
+      serviceConfig.UMask = lib.mkForce "0002";
+    };
+
+    samba-smbd = {
+      requires = [ "samba-setup.service" ];
+      bindsTo = [
+        homesMount
+        mediaMount
+      ];
+      unitConfig.RequiresMountsFor = [
+        "/storage/homes/public"
+        "/storage/media"
+      ];
+    };
+
+    sonarr = {
+      bindsTo = [ mediaMount ];
+      unitConfig.RequiresMountsFor = [ "/storage/media" ];
+      serviceConfig.UMask = lib.mkForce "0002";
+    };
+  };
+}

--- a/modules/nixos/backrest.nix
+++ b/modules/nixos/backrest.nix
@@ -109,8 +109,6 @@ in
 
     systemd.services.backrest = {
       description = "Backrest web UI";
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {

--- a/modules/nixos/healthchecks.nix
+++ b/modules/nixos/healthchecks.nix
@@ -1,6 +1,5 @@
 # report a service's success/failure to healthchecks.io
-# each template is instantiated with the name of the unit being reported on and the action (start, success, failure)
-# example: healthchecks-ping@restic-backups-system-backup:start, ...
+# each monitored unit gets dedicated start, success, and failure ping services
 {
   config,
   lib,
@@ -8,11 +7,79 @@
   ...
 }:
 let
-  cfg = lib.filterAttrs (_: v: v.urlFile != null || v.url != null) config.services.healthchecks-ping;
-  urlFiles = lib.mapAttrsToList (n: v: {
-    name = n;
-    path = if v.url != null then (pkgs.writeText "healthchecks-${n}" "HC_URL=${v.url}") else v.urlFile;
-  }) cfg;
+  cfg = config.services.healthchecks-ping;
+  isValid = value: (value.urlFile == null) != (value.url == null);
+  validCfg = lib.filterAttrs (_: isValid) cfg;
+  actions = [
+    "start"
+    "success"
+    "fail"
+  ];
+  pingServiceName = name: action: "healthchecks-ping-${name}-${action}";
+  urlFile =
+    name: value:
+    if value.url != null then
+      pkgs.writeText "healthchecks-${name}" "HC_URL=${value.url}"
+    else
+      value.urlFile;
+  pingServices = lib.listToAttrs (
+    lib.concatLists (
+      lib.mapAttrsToList (
+        name: value:
+        map (
+          action:
+          lib.nameValuePair (pingServiceName name action) {
+            description = "Pings healthchecks.io for ${name} (${action})";
+            wants = [ "network-online.target" ];
+            after = [ "network-online.target" ];
+            serviceConfig = {
+              Type = "oneshot";
+              LoadCredential = [ "url:${urlFile name value}" ];
+              # Hardening
+              # DynamicUser = true; # disabled, because call to `systemctl show` requires root privileges
+              ProtectSystem = "strict";
+              ProtectHome = "read-only";
+              PrivateTmp = true;
+              RestrictSUIDSGID = true;
+              PrivateDevices = true; # Only allow access to pseudo-devices (eg: null, random, zero) in separate namespace
+              PrivateUsers = true;
+              SupplementaryGroups = "systemd-journal"; # Allow access to journal
+              ProtectClock = true;
+              ProtectControlGroups = true;
+              ProtectKernelLogs = true;
+              ProtectKernelModules = true;
+              ProtectKernelTunables = true;
+              ProtectProc = "invisible";
+              RestrictAddressFamilies = [
+                "AF_UNIX"
+                "AF_INET"
+                "AF_INET6"
+              ];
+              RestrictNamespaces = true;
+              RestrictRealtime = true;
+              SystemCallArchitectures = "native";
+              SystemCallFilter = "@system-service";
+              SystemCallErrorNumber = "EPERM";
+            };
+            # journalctl -I requires systemd v257.
+            script = ''
+              url=$(grep -oP "^HC_URL=\K.+" "$CREDENTIALS_DIRECTORY/url")
+
+              if [ ${lib.escapeShellArg action} = success ]; then
+                logs=$(journalctl -I -u ${lib.escapeShellArg "${name}.service"} -n 100 --no-pager --output=short-iso)
+                echo "$logs" | ${lib.getExe pkgs.curl} -fsS -m 10 --retry 5 --data-binary @- "$url"
+              elif [ ${lib.escapeShellArg action} = fail ]; then
+                logs=$(journalctl -I -u ${lib.escapeShellArg "${name}.service"} -n 100 --no-pager --output=short-iso)
+                echo "$logs" | ${lib.getExe pkgs.curl} -fsS -m 10 --retry 5 --data-binary @- "$url/fail"
+              else
+                ${lib.getExe pkgs.curl} -fsS -m 10 --retry 5 "$url/${action}"
+              fi
+            '';
+          }
+        ) actions
+      ) validCfg
+    )
+  );
 in
 {
   options.services.healthchecks-ping = lib.mkOption {
@@ -51,79 +118,21 @@ in
   };
 
   config = lib.mkIf (cfg != { }) {
-    assertions =
-      lib.mapAttrsToList (n: v: {
-        assertion = (v.urlFile == null) != (v.url == null);
-        message = "services.healthchecks-ping.${n}: exactly one of url or urlFile should be set";
-      }) cfg
-      ++ lib.mapAttrsToList (n: _: {
-        assertion = lib.hasAttr n config.systemd.services;
-        message = "services.healthchecks-ping.${n}: no matching systemd service found";
-      }) cfg;
+    assertions = lib.mapAttrsToList (n: v: {
+      assertion = isValid v;
+      message = "services.healthchecks-ping.${n}: exactly one of url or urlFile should be set";
+    }) cfg;
 
     systemd.services = lib.mkMerge [
       (lib.mapAttrs' (
         name: _val:
         lib.nameValuePair name {
-          wants = [ "healthchecks-ping@${name}:start.service" ];
-          onSuccess = [ "healthchecks-ping@${name}:success.service" ];
-          onFailure = [ "healthchecks-ping@${name}:fail.service" ];
+          wants = [ "${pingServiceName name "start"}.service" ];
+          onSuccess = [ "${pingServiceName name "success"}.service" ];
+          onFailure = [ "${pingServiceName name "fail"}.service" ];
         }
-      ) cfg)
-      {
-        "healthchecks-ping@" = {
-          description = "Pings healthchecks.io (%i)";
-          serviceConfig = {
-            Type = "oneshot";
-            LoadCredential = map ({ name, path }: "${name}:${path}") urlFiles;
-            # Hardening
-            # DynamicUser = true; # disabled, because call to `systemctl show` requires root privileges
-            ProtectSystem = "strict";
-            ProtectHome = "read-only";
-            PrivateTmp = true;
-            RestrictSUIDSGID = true;
-            PrivateDevices = true; # Only allow access to pseudo-devices (eg: null, random, zero) in separate namespace
-            PrivateUsers = true;
-            SupplementaryGroups = "systemd-journal"; # Allow access to journal
-            ProtectClock = true;
-            ProtectControlGroups = true;
-            ProtectKernelLogs = true;
-            ProtectKernelModules = true;
-            ProtectKernelTunables = true;
-            ProtectProc = "invisible";
-            RestrictAddressFamilies = [
-              "AF_UNIX"
-              "AF_INET"
-              "AF_INET6"
-            ];
-            RestrictNamespaces = true;
-            RestrictRealtime = true;
-            SystemCallArchitectures = "native";
-            SystemCallFilter = "@system-service";
-            SystemCallErrorNumber = "EPERM";
-          };
-          scriptArgs = "%i"; # name:action
-          # requires systemd v257 (journalctl has -I flag for latest invocation)
-          script = ''
-            # set -x # for debugging
-            IFS=':' read -r name action <<< "$1"
-
-            # read the value of HC_URL from the file (file may contain other variables too)
-            url=$(grep -oP "^HC_URL=\K.+" "$CREDENTIALS_DIRECTORY/$name")
-
-            if [ "$action" = "success" ]; then
-              # last 1000 lines
-              logs=$(journalctl -I -u "$name.service" -n 100 --no-pager --output=short-iso)
-              echo "$logs" | ${lib.getExe pkgs.curl} -fsS -m 10 --retry 5 --data-binary @- "$url"
-            elif [ "$action" = "fail" ]; then
-              logs=$(journalctl -I -u "$name.service" -n 100 --no-pager --output=short-iso)
-              echo "$logs" | ${lib.getExe pkgs.curl} -fsS -m 10 --retry 5 --data-binary @- "$url/fail"
-            else
-              ${lib.getExe pkgs.curl} -fsS -m 10 --retry 5 "$url/$action"
-            fi
-          '';
-        };
-      }
+      ) validCfg)
+      pingServices
     ];
   };
 }

--- a/modules/nixos/rclone-sync.nix
+++ b/modules/nixos/rclone-sync.nix
@@ -59,7 +59,6 @@ in
               type = with types; listOf str;
               default = [
                 "--transfers=32"
-                "--b2-hard-delete"
                 "--fast-list"
               ];
               description = ''
@@ -102,17 +101,13 @@ in
   };
 
   config = {
-    assertions = lib.mapAttrsToList (name: value: {
-      assertion = value.dataDir != null;
-      message = "services.rclone-sync.${name}.dataDir must be a valid path";
-    }) cfg;
-
     systemd.services = lib.mapAttrs' (
       name: remoteConfig:
       lib.nameValuePair "rclone-sync-${name}" {
         description = "Rclone ${remoteConfig.rcloneCommand} for '${name}' from ${remoteConfig.dataDir}";
         wants = [ "network-online.target" ];
         after = [ "network-online.target" ];
+        unitConfig.RequiresMountsFor = [ remoteConfig.dataDir ];
         serviceConfig = {
           Type = "oneshot";
           LoadCredential = [ "rcloneConf:${remoteConfig.rcloneConfFile}" ];


### PR DESCRIPTION
## Summary

- Centralize Terminus storage mounts, media permissions, and service dependencies.
- Simplify Tailscale Serve route definitions and improve service startup ordering.
- Replace templated Healthchecks units with dedicated hardened ping services.
- Tune rclone Backblaze sync options and add mount dependencies.
- Clean up obsolete per-service mount and group configuration.

## Testing

- Not run (not requested).