### PR TITLE
Automate custom package updates in CI

### DIFF
--- a/.github/workflows/update-pkgs.yml
+++ b/.github/workflows/update-pkgs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@33c9ab3ef95cd57c164d9d6eb1f9a46338538d41 # main, pinned 2026-07-13
 
       - name: Update custom packages
-        run: nix run nixpkgs#just -- pkgs-update
+        run: nix run .#update-packages
 
       - name: Detect package updates
         id: changes
@@ -42,7 +42,15 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         run: |
           git diff --check
-          nix build .#smartrent-py .#hass-smartrent --no-link -L
+          mapfile -t package_names < <(
+            nix eval --raw .#packages.x86_64-linux \
+              --apply 'packages: builtins.concatStringsSep "\n" (builtins.attrNames packages) + "\n"'
+          )
+          installables=()
+          for package_name in "${package_names[@]}"; do
+            installables+=(".#$package_name")
+          done
+          nix build "${installables[@]}" --no-link -L
 
       - name: Create or update pull request
         if: steps.changes.outputs.changed == 'true'

--- a/flake.nix
+++ b/flake.nix
@@ -107,10 +107,53 @@
         system: treefmt-nix.lib.evalModule nixpkgs.legacyPackages.${system} ./treefmt.nix
       );
 
-      packages =
-        nixpkgs.lib.attrsets.recursiveUpdate
-          (helper.forAllSystems (system: import ./pkgs { pkgs = nixpkgs.legacyPackages.${system}; }))
-          (helper.forLinuxSystems (system: import ./pkgsLinux { pkgs = nixpkgs.legacyPackages.${system}; }));
+      pkgsFor = helper.forAllSystems (
+        system:
+        import nixpkgs {
+          inherit system;
+          config.allowUnfreePredicate = package: nixpkgs.lib.getName package == "chatgpt";
+        }
+      );
+
+      packages = nixpkgs.lib.attrsets.recursiveUpdate (helper.forAllSystems (
+        system: import ./pkgs { pkgs = pkgsFor.${system}; }
+      )) (helper.forLinuxSystems (system: import ./pkgsLinux { pkgs = pkgsFor.${system}; }));
+
+      updatePackagesApp =
+        system:
+        let
+          inherit (nixpkgs) lib;
+          pkgs = nixpkgs.legacyPackages.${system};
+          updateablePackages = lib.filterAttrs (_: package: package ? updateScript) packages.${system};
+          updateCommands = lib.mapAttrsToList (
+            attrPath: package:
+            let
+              updateScript = package.updateScript.command or package.updateScript;
+            in
+            ''
+              echo "Updating ${attrPath}"
+              export UPDATE_NIX_ATTR_PATH=${lib.escapeShellArg attrPath}
+              export UPDATE_NIX_NAME=${lib.escapeShellArg package.name}
+              export UPDATE_NIX_PNAME=${lib.escapeShellArg (package.pname or (lib.getName package))}
+              export UPDATE_NIX_OLD_VERSION=${lib.escapeShellArg (package.version or (lib.getVersion package))}
+              ${lib.escapeShellArgs (map toString (lib.toList updateScript))}
+            ''
+          ) updateablePackages;
+          updater = pkgs.writeShellApplication {
+            name = "update-packages";
+            runtimeInputs = [ pkgs.git ];
+            text = ''
+              repo_root="$(git rev-parse --show-toplevel)"
+              cd "$repo_root"
+
+              ${lib.concatStringsSep "\n" updateCommands}
+            '';
+          };
+        in
+        {
+          type = "app";
+          program = lib.getExe updater;
+        };
     in
     {
       inherit
@@ -121,6 +164,9 @@
         ;
 
       formatter = helper.forAllSystems (system: treefmtEval.${system}.config.build.wrapper);
+      apps = helper.forAllSystems (system: {
+        update-packages = updatePackagesApp system;
+      });
       checks = helper.forAllSystems (system: {
         formatting = treefmtEval.${system}.config.build.check self;
       });

--- a/justfile
+++ b/justfile
@@ -3,11 +3,6 @@ default:
 
 alias s := switch
 
-pkgs-update:
-    nix run nixpkgs#nix-update -- smartrent-py --flake
-    # Note: the next command requires an x86_64-linux builder and fails without one.
-    nix run nixpkgs#nix-update -- hass-smartrent --flake --system x86_64-linux
-
 [macos]
 switch:
     # sudo darwin-rebuild switch --flake .

--- a/pkgs/smartrent-py/package.nix
+++ b/pkgs/smartrent-py/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  nix-update-script,
   # runtime
   websockets,
   aiohttp,
@@ -46,6 +47,10 @@ buildPythonPackage rec {
   # dependency/API breakage still fails the build at package time.
   doCheck = false;
   pythonImportsCheck = [ "smartrent" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--flake" ];
+  };
 
   meta = with lib; {
     description = "Api for SmartRent locks, thermostats, moisture sensors, and switches";

--- a/pkgsLinux/chatgpt/default.nix
+++ b/pkgsLinux/chatgpt/default.nix
@@ -11,11 +11,15 @@
   at-spi2-core,
   atk,
   cairo,
+  coreutils,
   cups,
+  curl,
   dbus,
   expat,
   gdk-pixbuf,
+  git,
   glib,
+  gnused,
   gtk3,
   libdrm,
   libgbm,
@@ -29,18 +33,34 @@
   libxrandr,
   nspr,
   nss,
+  nix,
   pango,
   systemd,
   udev,
+  writeShellApplication,
   xdg-utils,
 }:
+let
+  updateScript = writeShellApplication {
+    name = "update-chatgpt";
+    runtimeInputs = [
+      coreutils
+      curl
+      dpkg
+      git
+      gnused
+      nix
+    ];
+    text = builtins.readFile ./update.sh;
+  };
+in
 stdenv.mkDerivation (_finalAttrs: {
   pname = "chatgpt";
-  version = "26.825.31414";
+  version = "26.825.51511";
 
   src = fetchurl {
     url = "https://persistent.oaistatic.com/codex-app-prod/linux/deb/latest/chatgpt_amd64.deb";
-    hash = "sha256-wXMEi6gPevnNiQT5ofJyr/SUejFPb+l9obuDaEds3Pk=";
+    hash = "sha256-NVSwAixs+1EzJvQ/0R9xiDWncIasTXyi/z67ui1Mf0U=";
   };
 
   nativeBuildInputs = [
@@ -123,7 +143,10 @@ stdenv.mkDerivation (_finalAttrs: {
     mv $out/bin/.chatgpt-wrapped $out/bin/chatgpt
   '';
 
-  passthru.updateScript = ./update.sh;
+  passthru.updateScript = [
+    (lib.getExe updateScript)
+    "pkgsLinux/chatgpt/default.nix"
+  ];
 
   meta = {
     description = "ChatGPT desktop app with Codex integration";

--- a/pkgsLinux/chatgpt/update.sh
+++ b/pkgsLinux/chatgpt/update.sh
@@ -5,6 +5,7 @@
 set -euo pipefail
 
 url="https://persistent.oaistatic.com/codex-app-prod/linux/deb/latest/chatgpt_amd64.deb"
+package_path="${1:?package path is required}"
 deb="$(mktemp)"
 trap 'rm -f "$deb"' EXIT
 
@@ -12,8 +13,8 @@ curl --fail --location --silent --show-error --output "$deb" "$url"
 
 version="$(dpkg-deb --field "$deb" Version)"
 hash="$(nix hash file "$deb")"
-package_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-package_file="$package_dir/default.nix"
+repo_root="$(git rev-parse --show-toplevel)"
+package_file="$repo_root/$package_path"
 
 sed --in-place --regexp-extended \
   --expression="s|^([[:space:]]*version = )\"[^\"]+\";|\1\"$version\";|" \

--- a/pkgsLinux/homeassistant-customcomponents/smartrent/package.nix
+++ b/pkgsLinux/homeassistant-customcomponents/smartrent/package.nix
@@ -23,9 +23,15 @@ buildHomeAssistantComponent rec {
     (home-assistant.python3Packages.callPackage ../../../pkgs/smartrent-py/package.nix { })
   ];
 
-  # manual updates: `cd` to pkgsLinux directory and run
-  # `nix-update hass-smartrent`
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--flake"
+      "--system"
+      "x86_64-linux"
+      "--override-filename"
+      "pkgsLinux/homeassistant-customcomponents/smartrent/package.nix"
+    ];
+  };
 
   meta = with lib; {
     # changelog, description, homepage, license, maintainers


### PR DESCRIPTION
## Summary

- Add a flake app that discovers and runs update scripts for all custom packages
- Configure package-specific update scripts for SmartRent and ChatGPT
- Update CI to use the new updater and build every discovered package
- Remove the obsolete justfile update recipe

## Testing

Not run (not requested)