### PR TITLE
Add Brother scan-key support to Terminus

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -111,7 +111,12 @@
         system:
         import nixpkgs {
           inherit system;
-          config.allowUnfreePredicate = package: nixpkgs.lib.getName package == "chatgpt";
+          config.allowUnfreePredicate =
+            package:
+            builtins.elem (nixpkgs.lib.getName package) [
+              "brscan-skey"
+              "chatgpt"
+            ];
         }
       );
 

--- a/hosts/nixos/terminus/default.nix
+++ b/hosts/nixos/terminus/default.nix
@@ -32,6 +32,7 @@
     ./services/copyparty.nix
     ./services/home-assistant
     ./services/ollama.nix
+    ./services/brscan-skey.nix
     ./services/paperless.nix
     ./services/servarr
     ./services/samba.nix
@@ -42,6 +43,7 @@
     ./services/vscode-server.nix
 
     ../../../modules/nixos/backrest.nix
+    ../../../modules/nixos/brscan-skey.nix
     ../../../modules/nixos/healthchecks.nix
     ../../../modules/nixos/rclone-sync.nix
     inputs.lanzaboote.nixosModules.lanzaboote

--- a/hosts/nixos/terminus/services/brscan-skey.nix
+++ b/hosts/nixos/terminus/services/brscan-skey.nix
@@ -1,0 +1,23 @@
+{ pkgs, ... }:
+{
+  # AirScan handles normal driverless scanning. The proprietary scan-key
+  # daemon uses brscan5's network-device registry to subscribe to button
+  # events from the scanner.
+  hardware.sane = {
+    enable = true;
+    extraBackends = [ pkgs.sane-airscan ];
+    brscan5 = {
+      enable = true;
+      netDevices.Brother_DCP_L2647DW = {
+        model = "DCP-L2647DW";
+        nodename = "BRW44F79FE0D797";
+      };
+    };
+  };
+
+  services.brscan-skey = {
+    enable = true;
+    scanDirectory = "/storage/homes/public/scans";
+    scanFileUmask = "0022";
+  };
+}

--- a/hosts/nixos/terminus/services/paperless.nix
+++ b/hosts/nixos/terminus/services/paperless.nix
@@ -1,6 +1,7 @@
 { config, ... }:
 let
   inherit (config.networking) domain;
+  consumptionDir = "/storage/homes/public/scans";
 in
 {
   age.secrets.paperless-admin.file = ../secrets/paperless-admin.age;
@@ -8,6 +9,10 @@ in
   services.paperless = {
     enable = true;
     passwordFile = config.age.secrets.paperless-admin.path;
+    inherit consumptionDir;
+    # This makes the directory mode 0777, allowing the isolated scanner
+    # service to write here without sharing a Unix group with Paperless.
+    consumptionDirIsPublic = true;
     settings = {
       PAPERLESS_URL = "https://paperless.${domain}";
       PAPERLESS_FILENAME_FORMAT = "{{ created_year }}/{{ correspondent }}/{{ created }} {{ title }}";

--- a/modules/nixos/brscan-skey.nix
+++ b/modules/nixos/brscan-skey.nix
@@ -1,0 +1,186 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.brscan-skey;
+  brscan5Path = "${pkgs.brscan5}/opt/brother/scanner/brscan5";
+  packagePath = "${cfg.package}/opt/brother/scanner/brscan-skey";
+in
+{
+  meta.maintainers = [ lib.maintainers.josephst ];
+
+  options.services.brscan-skey = {
+    enable = lib.mkEnableOption "the Brother scan-key tool";
+
+    package = lib.mkPackageOption pkgs "brscan-skey" { };
+
+    scanDirectory = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/brscan-skey-scans";
+      description = ''
+        Directory in which the Brother Scan to File action writes scans.
+        The directory is created with the scanner service user as owner and
+        the scanner service group as group. Keep this outside /home because
+        the service protects home directories with ProtectHome.
+      '';
+      example = "/storage/homes/public/scans";
+    };
+
+    scanDirectoryMode = lib.mkOption {
+      type = lib.types.strMatching "[0-7]{4}";
+      default = "0750";
+      description = ''
+        Mode for the scan directory. The default permits the scanner service
+        group to read and traverse it, without making scans world-readable.
+
+        When the scan directory is also services.paperless.consumptionDir,
+        Paperless manages the directory's mode and ownership instead.
+      '';
+    };
+
+    scanFileUmask = lib.mkOption {
+      type = lib.types.strMatching "[0-7]{4}";
+      default = "0027";
+      description = ''
+        Process umask applied to generated scans. The default keeps files
+        private to the scanner user and group. Use 0022 when another service
+        must read scans through a world-accessible directory.
+      '';
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "brscan-skey";
+      description = "User account under which the scan-key tool runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "brscan-skey";
+      description = "Group used for scan-directory access.";
+    };
+
+    privateDevices = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Hide host device nodes from the scan-key service. This is appropriate
+        for network-connected scanners; set to false when the scanner is
+        connected over USB.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.scanDirectory != "/";
+        message = "services.brscan-skey.scanDirectory must not be the filesystem root";
+      }
+    ];
+
+    users.groups = lib.mkIf (cfg.group == "brscan-skey") {
+      brscan-skey = { };
+    };
+
+    users.users = lib.mkIf (cfg.user == "brscan-skey") {
+      brscan-skey = {
+        description = "Brother scan-key tool service user";
+        inherit (cfg) group;
+        isSystemUser = true;
+      };
+    };
+
+    # Paperless owns its consumption directory when the two options point at
+    # the same path. Otherwise, retain a self-contained default for users of
+    # this module without Paperless.
+    systemd.tmpfiles.settings."10-brscan-skey" =
+      lib.mkIf
+        (!config.services.paperless.enable || cfg.scanDirectory != config.services.paperless.consumptionDir)
+        {
+          ${cfg.scanDirectory}.d = {
+            inherit (cfg) group;
+            mode = cfg.scanDirectoryMode;
+            inherit (cfg) user;
+          };
+        };
+
+    systemd.services.brscan-skey = {
+      description = "Brother scan-key tool";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+
+      unitConfig.RequiresMountsFor = [ cfg.scanDirectory ];
+
+      serviceConfig = {
+        Type = "forking";
+        ExecStart = "${packagePath}/brscan-skey";
+        ExecStop = "${packagePath}/brscan-skey --terminate";
+        Group = cfg.group;
+        User = cfg.user;
+
+        Environment = [
+          "BRSCAN_SKEY_SCAN_DIR=${cfg.scanDirectory}"
+          "HOME=/var/lib/brscan-skey"
+          "SANE_CONFIG_DIR=/etc/sane-config"
+          "LD_LIBRARY_PATH=/etc/sane-libs"
+          "PATH=${
+            lib.makeBinPath [
+              pkgs.bash
+              pkgs.coreutils
+              pkgs.curl
+              pkgs.gnugrep
+            ]
+          }"
+        ];
+
+        StateDirectory = "brscan-skey";
+        StateDirectoryMode = "0700";
+        WorkingDirectory = "/var/lib/brscan-skey";
+        ReadWritePaths = [ cfg.scanDirectory ];
+        UMask = cfg.scanFileUmask;
+
+        # The vendor binaries require their historical paths. Expose only the
+        # package's scan-key subtree, read-only, inside this service namespace;
+        # no /opt files are created on the host.
+        BindReadOnlyPaths = [
+          "${packagePath}:/opt/brother/scanner/brscan-skey"
+          "${packagePath}:/etc/opt/brother/scanner/brscan-skey"
+        ]
+        ++ lib.optional config.hardware.sane.brscan5.enable "${brscan5Path}:/opt/brother/scanner/brscan5";
+
+        Restart = "on-failure";
+        RestartSec = 5;
+
+        NoNewPrivileges = true;
+        PrivateDevices = cfg.privateDevices;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        CapabilityBoundingSet = "";
+        AmbientCapabilities = "";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+      };
+    };
+  };
+}

--- a/modules/nixos/brscan-skey.nix
+++ b/modules/nixos/brscan-skey.nix
@@ -9,6 +9,10 @@ let
   cfg = config.services.brscan-skey;
   brscan5Path = "${pkgs.brscan5}/opt/brother/scanner/brscan5";
   packagePath = "${cfg.package}/opt/brother/scanner/brscan-skey";
+  scanConfig = pkgs.writeText "brscan-skey-scantofile.config" ''
+    source ${packagePath}/scantofile.config
+    resolution=${toString cfg.scanResolution}
+  '';
 in
 {
   meta.maintainers = [ lib.maintainers.josephst ];
@@ -49,6 +53,16 @@ in
         Process umask applied to generated scans. The default keeps files
         private to the scanner user and group. Use 0022 when another service
         must read scans through a world-accessible directory.
+      '';
+    };
+
+    scanResolution = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 300;
+      example = 600;
+      description = ''
+        Resolution in dots per inch for the Scan to File action.
+        Choose a resolution supported by the scanner.
       '';
     };
 
@@ -129,6 +143,8 @@ in
           "HOME=/var/lib/brscan-skey"
           "SANE_CONFIG_DIR=/etc/sane-config"
           "LD_LIBRARY_PATH=/etc/sane-libs"
+          # Vendor scripts invoke the bundled skey-scanimage by absolute
+          # path; PATH supplies their shell utilities, not SANE's scanimage.
           "PATH=${
             lib.makeBinPath [
               pkgs.bash
@@ -151,6 +167,9 @@ in
         BindReadOnlyPaths = [
           "${packagePath}:/opt/brother/scanner/brscan-skey"
           "${packagePath}:/etc/opt/brother/scanner/brscan-skey"
+          # The vendor script checks its per-user config first. Mount the
+          # generated settings there to override the packaged resolution.
+          "${scanConfig}:/var/lib/brscan-skey/.brscan-skey/scantofile.config"
         ]
         ++ lib.optional config.hardware.sane.brscan5.enable "${brscan5Path}:/opt/brother/scanner/brscan5";
 
@@ -178,6 +197,10 @@ in
         RestrictAddressFamilies = [
           "AF_INET"
           "AF_INET6"
+          # brscan5 initializes libusb even for network scanners. Its udev
+          # monitor needs Netlink; blocking it makes libusb_init fail and
+          # the vendor driver crash during scanner discovery.
+          "AF_NETLINK"
           "AF_UNIX"
         ];
       };

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -5,4 +5,5 @@
   rcloneSync = import ./rclone-sync.nix;
   healthchecks = import ./healthchecks.nix;
   backrest = import ./backrest.nix;
+  brscanSkey = import ./brscan-skey.nix;
 }

--- a/pkgsLinux/brscan-skey/default.nix
+++ b/pkgsLinux/brscan-skey/default.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  bash,
+  coreutils,
+  curl,
+  gnugrep,
+  libredirect,
+  makeWrapper,
+  nix-update-script,
+  rpmextract,
+  sane-backends,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "brscan-skey";
+  version = "0.3.5";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf006650/${pname}-${version}-0.x86_64.rpm";
+    hash = "sha256-AdyFnxl45kUUfO1exLVEjMPiaxxtLxEEg09YkcDhdGk=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+    rpmextract
+  ];
+
+  buildInputs = [ sane-backends ];
+
+  unpackPhase = ''
+    rpmextract $src
+  '';
+
+  postPatch = ''
+        # The vendor's file action defaults to ~/brscan. Keep the standalone
+        # command compatible while allowing the system service to select a
+        # dedicated, shared directory through BRSCAN_SKEY_SCAN_DIR.
+        substituteInPlace opt/brother/scanner/brscan-skey/script/scantofile.sh \
+          --replace-fail 'mkdir -p ~/brscan' \
+            'SCAN_DIR="''${BRSCAN_SKEY_SCAN_DIR:-$HOME/brscan}"
+    mkdir -p "$SCAN_DIR"' \
+          --replace-fail 'OUTPUT=~/brscan/brscan_"$(date +%Y-%m-%d-%H-%M-%S)".tif' \
+            'OUTPUT="$SCAN_DIR/brscan_$(date +%Y-%m-%d-%H-%M-%S).tif"'
+
+        patchShebangs opt/brother/scanner/brscan-skey
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp -a opt "$out/"
+
+    # The vendor shell launcher invokes its helper with an absolute path.
+    # Point that one launcher edge at the immutable Nix store copy; the
+    # helper's own /opt lookups are handled by the wrapper below or the
+    # service's mount namespace.
+    substituteInPlace "$out/opt/brother/scanner/brscan-skey/brscan-skey" \
+      --replace-fail \
+        '/opt/brother/scanner/brscan-skey/brscan-skey-exe' \
+        "$out/opt/brother/scanner/brscan-skey/brscan-skey-exe"
+
+    # The binaries and vendor scripts use Brother's traditional absolute
+    # /opt and /etc/opt paths. Redirect those paths for direct invocations;
+    # the NixOS service uses an equivalent read-only mount namespace.
+    makeWrapper \
+      "$out/opt/brother/scanner/brscan-skey/brscan-skey" \
+      "$out/bin/brscan-skey" \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          bash
+          coreutils
+          curl
+          gnugrep
+        ]
+      }" \
+      --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS \
+        "/opt/brother/scanner/brscan-skey=$out/opt/brother/scanner/brscan-skey:/etc/opt/brother/scanner/brscan-skey=$out/opt/brother/scanner/brscan-skey"
+
+    mkdir -p "$out/share/licenses/$pname"
+    cp -p "$out/opt/brother/scanner/brscan-skey/LICENSE_ENG.txt" \
+      "$out/share/licenses/$pname/"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Brother scan-key tool for starting scans from a device button";
+    homepage = "https://support.brother.com/";
+    license = lib.licenses.unfree;
+    mainProgram = "brscan-skey";
+    maintainers = with lib.maintainers; [ josephst ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgsLinux/brscan-skey/default.nix
+++ b/pkgsLinux/brscan-skey/default.nix
@@ -7,6 +7,7 @@
   coreutils,
   curl,
   gnugrep,
+  libtiff,
   libredirect,
   makeWrapper,
   nix-update-script,
@@ -36,17 +37,78 @@ stdenv.mkDerivation rec {
   '';
 
   postPatch = ''
-        # The vendor's file action defaults to ~/brscan. Keep the standalone
-        # command compatible while allowing the system service to select a
-        # dedicated, shared directory through BRSCAN_SKEY_SCAN_DIR.
-        substituteInPlace opt/brother/scanner/brscan-skey/script/scantofile.sh \
-          --replace-fail 'mkdir -p ~/brscan' \
+            # The vendor's file action defaults to ~/brscan. Keep the standalone
+            # command compatible while allowing the system service to select a
+            # dedicated, shared directory through BRSCAN_SKEY_SCAN_DIR.
+            substituteInPlace opt/brother/scanner/brscan-skey/script/scantofile.sh \
+              --replace-fail 'mkdir -p ~/brscan' \
             'SCAN_DIR="''${BRSCAN_SKEY_SCAN_DIR:-$HOME/brscan}"
-    mkdir -p "$SCAN_DIR"' \
-          --replace-fail 'OUTPUT=~/brscan/brscan_"$(date +%Y-%m-%d-%H-%M-%S)".tif' \
-            'OUTPUT="$SCAN_DIR/brscan_$(date +%Y-%m-%d-%H-%M-%S).tif"'
+        STAGING_DIR="''${BRSCAN_SKEY_STAGING_DIR:-$HOME/.brscan-skey-staging}"
+        mkdir -p "$SCAN_DIR" "$STAGING_DIR"
+        TIFFCP="${libtiff}/bin/tiffcp"
+        TIFF2PDF="${libtiff}/bin/tiff2pdf"' \
+              --replace-fail 'OUTPUT=~/brscan/brscan_"$(date +%Y-%m-%d-%H-%M-%S)".tif' \
+                'OUTPUT="$SCAN_DIR/brscan_$(date +%Y-%m-%d-%H-%M-%S).pdf"
+        STAGING_BASENAME="$(basename "$OUTPUT" .pdf)"
+        STAGING_OUTPUT="$STAGING_DIR/$STAGING_BASENAME.tif"
+        COMPRESSED_OUTPUT="$STAGING_DIR/$STAGING_BASENAME.lzw.tif"
+        STAGING_PDF="$STAGING_DIR/$STAGING_BASENAME.pdf"' \
+              --replace-fail 'OPT_FILE="--outputfile  $OUTPUT"' \
+                'OPT_FILE="--outputfile  $STAGING_OUTPUT"' \
+              --replace-fail \
+                '$SCANIMAGE $OPT
 
-        patchShebangs opt/brother/scanner/brscan-skey
+    if [ ! -e "$OUTPUT" ];then
+       sleep 1
+       $SCANIMAGE $OPT
+    fi
+
+    echo "$OUTPUT" is created.' \
+                'run_scan() {
+      rm -f -- "$STAGING_OUTPUT"
+      $SCANIMAGE $OPT
+    }
+
+    run_scan
+
+    if [ ! -s "$STAGING_OUTPUT" ];then
+       sleep 1
+       run_scan
+    fi
+
+    if [ ! -s "$STAGING_OUTPUT" ];then
+       echo "Scan failed: $STAGING_OUTPUT is empty" >&2
+       rm -f -- "$STAGING_OUTPUT"
+       exit 1
+    fi
+
+    rm -f -- "$COMPRESSED_OUTPUT" "$STAGING_PDF"
+    if ! "$TIFFCP" -c lzw "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT";then
+       echo "Scan failed: could not compress $STAGING_OUTPUT" >&2
+       rm -f -- "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT"
+       exit 1
+    fi
+
+    if ! "$TIFF2PDF" "$COMPRESSED_OUTPUT" > "$STAGING_PDF" || [ ! -s "$STAGING_PDF" ];then
+       echo "Scan failed: could not convert $STAGING_OUTPUT to PDF" >&2
+       rm -f -- "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT" "$STAGING_PDF"
+       exit 1
+    fi
+
+    PUBLISH_OUTPUT="$SCAN_DIR/.$(basename "$OUTPUT").part"
+    rm -f -- "$PUBLISH_OUTPUT"
+    if ! cp -- "$STAGING_PDF" "$PUBLISH_OUTPUT" || [ ! -s "$PUBLISH_OUTPUT" ];then
+       echo "Scan failed: could not publish $OUTPUT" >&2
+       rm -f -- "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT" "$STAGING_PDF" "$PUBLISH_OUTPUT"
+       exit 1
+    fi
+
+    mv -- "$PUBLISH_OUTPUT" "$OUTPUT"
+    rm -f -- "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT" "$STAGING_PDF"
+
+    echo "$OUTPUT" is created.'
+
+            patchShebangs opt/brother/scanner/brscan-skey
   '';
 
   installPhase = ''

--- a/pkgsLinux/default.nix
+++ b/pkgsLinux/default.nix
@@ -4,5 +4,6 @@
   pkgs ? (import ../nixpkgs.nix { }),
 }:
 {
+  brscan-skey = pkgs.callPackage ./brscan-skey { };
   chatgpt = pkgs.callPackage ./chatgpt { };
 }


### PR DESCRIPTION
## Summary

- Package Brother’s proprietary `brscan-skey` tool for x86_64 Linux.
- Add a hardened NixOS module with configurable scan directory, permissions, service account, and device isolation.
- Enable scanner button-triggered scans on Terminus and integrate them with Paperless-ngx.

## Testing

- Not run (not requested).