### PR TITLE
Harden brscan-skey Paperless publication workflow

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -174,6 +174,7 @@
       });
       checks = helper.forAllSystems (system: {
         formatting = treefmtEval.${system}.config.build.check self;
+        brscan-skey = pkgsFor.${system}.callPackage ./pkgsLinux/brscan-skey/tests.nix { };
       });
 
       # NixOS configuration entrypoint

--- a/hosts/nixos/terminus/services/brscan-skey.nix
+++ b/hosts/nixos/terminus/services/brscan-skey.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 {
   # AirScan handles normal driverless scanning. The proprietary scan-key
   # daemon uses brscan5's network-device registry to subscribe to button
@@ -17,7 +17,7 @@
 
   services.brscan-skey = {
     enable = true;
-    scanDirectory = "/storage/homes/public/scans";
+    scanDirectory = config.services.paperless.consumptionDir;
     scanFileUmask = "0022";
   };
 }

--- a/hosts/nixos/terminus/services/paperless.nix
+++ b/hosts/nixos/terminus/services/paperless.nix
@@ -1,7 +1,6 @@
 { config, ... }:
 let
   inherit (config.networking) domain;
-  consumptionDir = "/storage/homes/public/scans";
 in
 {
   age.secrets.paperless-admin.file = ../secrets/paperless-admin.age;
@@ -9,9 +8,8 @@ in
   services.paperless = {
     enable = true;
     passwordFile = config.age.secrets.paperless-admin.path;
-    inherit consumptionDir;
-    # This makes the directory mode 0777, allowing the isolated scanner
-    # service to write here without sharing a Unix group with Paperless.
+    # Keep the default /var/lib/paperless/consume inbox public so the
+    # isolated scanner service can atomically publish completed files.
     consumptionDirIsPublic = true;
     settings = {
       PAPERLESS_URL = "https://paperless.${domain}";

--- a/modules/nixos/brscan-skey.nix
+++ b/modules/nixos/brscan-skey.nix
@@ -12,6 +12,7 @@ let
   scanConfig = pkgs.writeText "brscan-skey-scantofile.config" ''
     source ${packagePath}/scantofile.config
     resolution=${toString cfg.scanResolution}
+    size=${lib.escapeShellArg cfg.scanSize}
   '';
 in
 {
@@ -31,7 +32,7 @@ in
         the scanner service group as group. Keep this outside /home because
         the service protects home directories with ProtectHome.
       '';
-      example = "/storage/homes/public/scans";
+      example = "/var/lib/paperless/consume";
     };
 
     scanDirectoryMode = lib.mkOption {
@@ -63,6 +64,16 @@ in
       description = ''
         Resolution in dots per inch for the Scan to File action.
         Choose a resolution supported by the scanner.
+      '';
+    };
+
+    scanSize = lib.mkOption {
+      type = lib.types.strMatching "(MAX|A3|A4|A5|A6|Letter|Legal|[0-9]+(\\.[0-9]+)?x[0-9]+(\\.[0-9]+)?)";
+      default = "Letter";
+      example = "210x297";
+      description = ''
+        Paper size for the Scan to File action. Use a vendor paper-size name
+        or a widthxheight size in millimetres.
       '';
     };
 
@@ -109,9 +120,9 @@ in
       };
     };
 
-    # Paperless owns its consumption directory when the two options point at
-    # the same path. Otherwise, retain a self-contained default for users of
-    # this module without Paperless.
+    # The scan directory is the final file directory. When it is Paperless's
+    # consumption directory, Paperless owns its mode and ownership; the
+    # private staging directory remains inside StateDirectory.
     systemd.tmpfiles.settings."10-brscan-skey" =
       lib.mkIf
         (!config.services.paperless.enable || cfg.scanDirectory != config.services.paperless.consumptionDir)
@@ -140,6 +151,7 @@ in
 
         Environment = [
           "BRSCAN_SKEY_SCAN_DIR=${cfg.scanDirectory}"
+          "BRSCAN_SKEY_STAGING_DIR=/var/lib/brscan-skey/staging"
           "HOME=/var/lib/brscan-skey"
           "SANE_CONFIG_DIR=/etc/sane-config"
           "LD_LIBRARY_PATH=/etc/sane-libs"

--- a/pkgsLinux/brscan-skey/default.nix
+++ b/pkgsLinux/brscan-skey/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   autoPatchelfHook,
+  callPackage,
   bash,
   coreutils,
   curl,
@@ -13,8 +14,24 @@
   nix-update-script,
   rpmextract,
   sane-backends,
+  util-linux,
+  writeShellApplication,
 }:
 
+let
+  scanAction = writeShellApplication {
+    name = "brscan-scantofile";
+    runtimeInputs = [
+      coreutils
+      libtiff
+      util-linux
+    ];
+    # The action handles command failures explicitly to log their exit codes
+    # and preserve completed PDFs. Do not enable implicit errexit.
+    bashOptions = [ "nounset" ];
+    text = builtins.readFile ./scantofile.sh;
+  };
+in
 stdenv.mkDerivation rec {
   pname = "brscan-skey";
   version = "0.3.5";
@@ -37,78 +54,9 @@ stdenv.mkDerivation rec {
   '';
 
   postPatch = ''
-            # The vendor's file action defaults to ~/brscan. Keep the standalone
-            # command compatible while allowing the system service to select a
-            # dedicated, shared directory through BRSCAN_SKEY_SCAN_DIR.
-            substituteInPlace opt/brother/scanner/brscan-skey/script/scantofile.sh \
-              --replace-fail 'mkdir -p ~/brscan' \
-            'SCAN_DIR="''${BRSCAN_SKEY_SCAN_DIR:-$HOME/brscan}"
-        STAGING_DIR="''${BRSCAN_SKEY_STAGING_DIR:-$HOME/.brscan-skey-staging}"
-        mkdir -p "$SCAN_DIR" "$STAGING_DIR"
-        TIFFCP="${libtiff}/bin/tiffcp"
-        TIFF2PDF="${libtiff}/bin/tiff2pdf"' \
-              --replace-fail 'OUTPUT=~/brscan/brscan_"$(date +%Y-%m-%d-%H-%M-%S)".tif' \
-                'OUTPUT="$SCAN_DIR/brscan_$(date +%Y-%m-%d-%H-%M-%S).pdf"
-        STAGING_BASENAME="$(basename "$OUTPUT" .pdf)"
-        STAGING_OUTPUT="$STAGING_DIR/$STAGING_BASENAME.tif"
-        COMPRESSED_OUTPUT="$STAGING_DIR/$STAGING_BASENAME.lzw.tif"
-        STAGING_PDF="$STAGING_DIR/$STAGING_BASENAME.pdf"' \
-              --replace-fail 'OPT_FILE="--outputfile  $OUTPUT"' \
-                'OPT_FILE="--outputfile  $STAGING_OUTPUT"' \
-              --replace-fail \
-                '$SCANIMAGE $OPT
-
-    if [ ! -e "$OUTPUT" ];then
-       sleep 1
-       $SCANIMAGE $OPT
-    fi
-
-    echo "$OUTPUT" is created.' \
-                'run_scan() {
-      rm -f -- "$STAGING_OUTPUT"
-      $SCANIMAGE $OPT
-    }
-
-    run_scan
-
-    if [ ! -s "$STAGING_OUTPUT" ];then
-       sleep 1
-       run_scan
-    fi
-
-    if [ ! -s "$STAGING_OUTPUT" ];then
-       echo "Scan failed: $STAGING_OUTPUT is empty" >&2
-       rm -f -- "$STAGING_OUTPUT"
-       exit 1
-    fi
-
-    rm -f -- "$COMPRESSED_OUTPUT" "$STAGING_PDF"
-    if ! "$TIFFCP" -c lzw "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT";then
-       echo "Scan failed: could not compress $STAGING_OUTPUT" >&2
-       rm -f -- "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT"
-       exit 1
-    fi
-
-    if ! "$TIFF2PDF" "$COMPRESSED_OUTPUT" > "$STAGING_PDF" || [ ! -s "$STAGING_PDF" ];then
-       echo "Scan failed: could not convert $STAGING_OUTPUT to PDF" >&2
-       rm -f -- "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT" "$STAGING_PDF"
-       exit 1
-    fi
-
-    PUBLISH_OUTPUT="$SCAN_DIR/.$(basename "$OUTPUT").part"
-    rm -f -- "$PUBLISH_OUTPUT"
-    if ! cp -- "$STAGING_PDF" "$PUBLISH_OUTPUT" || [ ! -s "$PUBLISH_OUTPUT" ];then
-       echo "Scan failed: could not publish $OUTPUT" >&2
-       rm -f -- "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT" "$STAGING_PDF" "$PUBLISH_OUTPUT"
-       exit 1
-    fi
-
-    mv -- "$PUBLISH_OUTPUT" "$OUTPUT"
-    rm -f -- "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT" "$STAGING_PDF"
-
-    echo "$OUTPUT" is created.'
-
-            patchShebangs opt/brother/scanner/brscan-skey
+    substituteInPlace opt/brother/scanner/brscan-skey/scantofile.config \
+      --replace-fail 'size=A4' 'size=Letter'
+    patchShebangs opt/brother/scanner/brscan-skey
   '';
 
   installPhase = ''
@@ -116,6 +64,7 @@ stdenv.mkDerivation rec {
 
     mkdir -p "$out"
     cp -a opt "$out/"
+    ln -sf ${lib.getExe scanAction} "$out/opt/brother/scanner/brscan-skey/script/scantofile.sh"
 
     # The vendor shell launcher invokes its helper with an absolute path.
     # Point that one launcher edge at the immutable Nix store copy; the
@@ -151,7 +100,10 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests.scanAction = callPackage ./tests.nix { };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Brother scan-key tool for starting scans from a device button";

--- a/pkgsLinux/brscan-skey/scantofile.sh
+++ b/pkgsLinux/brscan-skey/scantofile.sh
@@ -41,6 +41,25 @@ OUTPUT="$SCAN_DIR/brscan_$(date +%Y-%m-%d-%H-%M-%S)_${JOB_DIR##*.}.pdf"
 STAGING_OUTPUT="$JOB_DIR/scan.tif"
 COMPRESSED_OUTPUT="$JOB_DIR/scan.lzw.tif"
 STAGING_PDF="$JOB_DIR/scan.pdf"
+pdf_complete=0
+
+# Invoked by the EXIT trap, including the explicit failure exits below.
+# shellcheck disable=SC2329
+cleanup() {
+  local status=$?
+  local temporary_files=("$STAGING_OUTPUT" "$COMPRESSED_OUTPUT")
+  if [ "$pdf_complete" -eq 0 ]; then
+    temporary_files+=("$STAGING_PDF")
+  fi
+  if ! rm -f -- "${temporary_files[@]}"; then
+    log_message "could not remove temporary files from $JOB_DIR"
+  fi
+  if [ ! -e "$STAGING_PDF" ] && ! rmdir "$JOB_DIR"; then
+    log_message "could not remove private job directory: $JOB_DIR"
+  fi
+  return "$status"
+}
+trap 'cleanup' EXIT
 
 resolution=${resolution:-100}
 size=${size:-Letter}
@@ -101,13 +120,11 @@ if [ ! -s "$STAGING_PDF" ]; then
   log_message "PDF conversion failed with exit code 0: output is empty; private output=$STAGING_PDF"
   exit 1
 fi
+pdf_complete=1
 
 # GNU mv --no-copy makes a cross-filesystem publication fail instead of
 # copying a completed document into the consumer directory.
 if mv --no-copy -T --update=none-fail -- "$STAGING_PDF" "$OUTPUT"; then
-  if ! rm -f -- "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT" || ! rmdir "$JOB_DIR"; then
-    log_message "scan published but could not clean private job directory: $JOB_DIR"
-  fi
   printf '%s is created.\n' "$OUTPUT"
   exit 0
 else

--- a/pkgsLinux/brscan-skey/scantofile.sh
+++ b/pkgsLinux/brscan-skey/scantofile.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# Brother's file action, with private intermediate files and completion-safe
+# publication into the configured scan directory.
+set -u
+
+SCAN_DIR="${BRSCAN_SKEY_SCAN_DIR:-$HOME/brscan}"
+STAGING_DIR="${BRSCAN_SKEY_STAGING_DIR:-$HOME/.brscan-skey-staging}"
+SCANIMAGE="${BRSCAN_SKEY_SCANIMAGE:-/opt/brother/scanner/brscan-skey/skey-scanimage}"
+
+log_message() {
+  # The vendor daemon can detach stdout/stderr, so keep failures in journald.
+  logger -t brscan-skey -- "$*" 2>/dev/null || :
+  printf '%s\n' "$*" >&2
+}
+
+if ! mkdir -p "$SCAN_DIR" || ! (umask 077; mkdir -p "$STAGING_DIR") || ! chmod 0700 "$STAGING_DIR"; then
+  log_message "cannot create scan or staging directory: scan=$SCAN_DIR staging=$STAGING_DIR"
+  exit 1
+fi
+
+if [ -r "$HOME/.brscan-skey/scantofile.config" ]; then
+  # shellcheck disable=SC1090,SC1091
+  . "$HOME/.brscan-skey/scantofile.config"
+elif [ -r /etc/opt/brother/scanner/brscan-skey/scantofile.config ]; then
+  # shellcheck disable=SC1091
+  . /etc/opt/brother/scanner/brscan-skey/scantofile.config
+fi
+
+DEVICE_NAME=${1-}
+if [ -z "$DEVICE_NAME" ]; then
+  log_message "scan failed: no device name supplied"
+  exit 2
+fi
+
+JOB_DIR=$(mktemp -d "$STAGING_DIR/job.XXXXXX") || {
+  log_message "scan failed: cannot create private staging directory under $STAGING_DIR"
+  exit 1
+}
+OUTPUT="$SCAN_DIR/brscan_$(date +%Y-%m-%d-%H-%M-%S)_${JOB_DIR##*.}.pdf"
+STAGING_OUTPUT="$JOB_DIR/scan.tif"
+COMPRESSED_OUTPUT="$JOB_DIR/scan.lzw.tif"
+STAGING_PDF="$JOB_DIR/scan.pdf"
+
+resolution=${resolution:-100}
+size=${size:-Letter}
+duplex=${duplex:-}
+
+SCAN_ARGS=(--device-name "$DEVICE_NAME" --resolution "$resolution" --size "$size")
+if [ "$duplex" = ON ]; then
+  SCAN_ARGS+=(--duplex --source ADF_C)
+else
+  SCAN_ARGS+=(--source FB)
+fi
+SCAN_ARGS+=(--outputfile "$STAGING_OUTPUT")
+
+if [[ "$DEVICE_NAME" == *net* ]]; then
+  sleep 1
+fi
+
+scan_status=1
+for attempt in 1 2; do
+  rm -f -- "$STAGING_OUTPUT"
+  if "$SCANIMAGE" "${SCAN_ARGS[@]}"; then
+    scan_status=0
+  else
+    scan_status=$?
+  fi
+  if [ "$scan_status" -eq 0 ] && [ -s "$STAGING_OUTPUT" ]; then
+    break
+  fi
+  log_message "scan attempt $attempt failed with exit code $scan_status; output=$STAGING_OUTPUT"
+  if [ "$scan_status" -eq 0 ]; then
+    scan_status=1
+  fi
+  [ "$attempt" -eq 2 ] || sleep 1
+done
+
+if [ "$scan_status" -ne 0 ] || [ ! -s "$STAGING_OUTPUT" ]; then
+  log_message "scan failed with exit code $scan_status; private output=$STAGING_OUTPUT"
+  exit "$scan_status"
+fi
+
+if tiffcp -c lzw "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT"; then
+  :
+else
+  conversion_status=$?
+  log_message "compression failed with exit code $conversion_status; input=$STAGING_OUTPUT"
+  exit "$conversion_status"
+fi
+
+if tiff2pdf "$COMPRESSED_OUTPUT" > "$STAGING_PDF"; then
+  :
+else
+  conversion_status=$?
+  log_message "PDF conversion failed with exit code $conversion_status; input=$COMPRESSED_OUTPUT"
+  exit "$conversion_status"
+fi
+
+if [ ! -s "$STAGING_PDF" ]; then
+  log_message "PDF conversion failed with exit code 0: output is empty; private output=$STAGING_PDF"
+  exit 1
+fi
+
+# GNU mv --no-copy makes a cross-filesystem publication fail instead of
+# copying a completed document into the consumer directory.
+if mv --no-copy -T --update=none-fail -- "$STAGING_PDF" "$OUTPUT"; then
+  if ! rm -f -- "$STAGING_OUTPUT" "$COMPRESSED_OUTPUT" || ! rmdir "$JOB_DIR"; then
+    log_message "scan published but could not clean private job directory: $JOB_DIR"
+  fi
+  printf '%s is created.\n' "$OUTPUT"
+  exit 0
+else
+  publish_status=$?
+  log_message "publication failed with exit code $publish_status; completed PDF retained at $STAGING_PDF; destination=$OUTPUT"
+  exit "$publish_status"
+fi

--- a/pkgsLinux/brscan-skey/test_scantofile.py
+++ b/pkgsLinux/brscan-skey/test_scantofile.py
@@ -79,11 +79,13 @@ sys.exit(status)
         return [args for name, args in map(json.loads, self.events.read_text().splitlines())
                 if name == tool]
 
-    def assert_failed(self, result, status, message):
+    def assert_failed(self, result, status, message, retain_pdf=False):
         self.assertEqual(result.returncode, status, result.stderr)
         self.assertNotIn("is created", result.stdout)
         self.assertEqual(list(self.inbox.iterdir()), [])
         self.assertTrue(any(message in " ".join(args) for args in self.calls("logger")))
+        if not retain_pdf:
+            self.assertEqual(list(self.staging.iterdir()), [])
 
     def test_success_publishes_only_pdf_and_cleans_private_files(self):
         result = self.run_scan()
@@ -138,12 +140,13 @@ sys.exit(status)
 
     def test_failed_move_keeps_completed_pdf_in_private_directory(self):
         result = self.run_scan(TEST_MV_STATUS="18")
-        self.assert_failed(result, 18, "publication failed with exit code 18")
+        self.assert_failed(result, 18, "publication failed with exit code 18", retain_pdf=True)
         pdfs = list(self.staging.glob("job.*/scan.pdf"))
         self.assertEqual(len(pdfs), 1)
         self.assertEqual(pdfs[0].read_bytes(), b"%PDF-complete")
         self.assertIn(str(pdfs[0]), result.stderr)
         self.assertEqual(stat.S_IMODE(pdfs[0].parent.stat().st_mode), 0o700)
+        self.assertEqual(list(pdfs[0].parent.iterdir()), pdfs)
 
 
 if __name__ == "__main__":

--- a/pkgsLinux/brscan-skey/test_scantofile.py
+++ b/pkgsLinux/brscan-skey/test_scantofile.py
@@ -1,0 +1,150 @@
+"""Exercise the scan action without scanner hardware or a running journal."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+class ScanActionTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="brscan-test-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.inbox = self.root / "inbox with spaces"
+        self.staging = self.root / "private staging"
+        self.events = self.root / "events.jsonl"
+        self.config = self.home / ".brscan-skey" / "scantofile.config"
+        self.config.parent.mkdir()
+        self.config.write_text("")
+        mock = self.bin / "mock"
+        mock.write_text(
+            "#!" + shutil.which("python3") + "\n" + r'''
+import json, os, pathlib, stat, subprocess, sys
+tool = pathlib.Path(sys.argv[0]).name
+args = sys.argv[1:]
+with open(os.environ["TEST_EVENTS"], "a") as f:
+    f.write(json.dumps([tool, args]) + "\n")
+status = int(os.environ.get("TEST_" + tool.upper() + "_STATUS", "0"))
+if tool == "scanner":
+    output = pathlib.Path(args[args.index("--outputfile") + 1])
+    assert stat.S_IMODE(output.parent.stat().st_mode) == 0o700
+    assert not list(pathlib.Path(os.environ["BRSCAN_SKEY_SCAN_DIR"]).iterdir())
+    if os.environ.get("TEST_EMPTY_SCAN") != "1":
+        output.write_bytes(b"TIFF data")
+elif tool == "tiffcp":
+    pathlib.Path(args[-1]).write_bytes(pathlib.Path(args[-2]).read_bytes())
+elif tool == "tiff2pdf":
+    if os.environ.get("TEST_EMPTY_PDF") != "1":
+        sys.stdout.buffer.write(b"%PDF-complete")
+elif tool == "mv":
+    assert args[:4] == ["--no-copy", "-T", "--update=none-fail", "--"]
+    if not status:
+        sys.exit(subprocess.run([os.environ["TEST_REAL_MV"], *args]).returncode)
+sys.exit(status)
+'''
+        )
+        mock.chmod(0o755)
+        for name in ["scanner", "tiffcp", "tiff2pdf", "logger", "mv", "sleep"]:
+            (self.bin / name).symlink_to(mock)
+        self.script = Path(__file__).with_name("scantofile.sh")
+        self.env = dict(os.environ)
+        self.env.update(
+            HOME=str(self.home),
+            PATH=str(self.bin) + os.pathsep + os.environ["PATH"],
+            BRSCAN_SKEY_SCAN_DIR=str(self.inbox),
+            BRSCAN_SKEY_STAGING_DIR=str(self.staging),
+            BRSCAN_SKEY_SCANIMAGE=str(self.bin / "scanner"),
+            TEST_EVENTS=str(self.events),
+            TEST_REAL_MV=shutil.which("mv"),
+        )
+
+    def run_scan(self, **env):
+        return subprocess.run(
+            [shutil.which("bash"), str(self.script), "brother net device with spaces"],
+            env={**self.env, **env}, capture_output=True, text=True, umask=0o022,
+        )
+
+    def calls(self, tool):
+        if not self.events.exists():
+            return []
+        return [args for name, args in map(json.loads, self.events.read_text().splitlines())
+                if name == tool]
+
+    def assert_failed(self, result, status, message):
+        self.assertEqual(result.returncode, status, result.stderr)
+        self.assertNotIn("is created", result.stdout)
+        self.assertEqual(list(self.inbox.iterdir()), [])
+        self.assertTrue(any(message in " ".join(args) for args in self.calls("logger")))
+
+    def test_success_publishes_only_pdf_and_cleans_private_files(self):
+        result = self.run_scan()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        outputs = list(self.inbox.iterdir())
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(outputs[0].suffix, ".pdf")
+        self.assertEqual(outputs[0].read_bytes(), b"%PDF-complete")
+        self.assertEqual(stat.S_IMODE(outputs[0].stat().st_mode), 0o644)
+        self.assertEqual(list(self.staging.iterdir()), [])
+        self.assertEqual(stat.S_IMODE(self.staging.stat().st_mode), 0o700)
+        args = self.calls("scanner")[0]
+        self.assertEqual(args[args.index("--device-name") + 1], "brother net device with spaces")
+        self.assertEqual(args[args.index("--size") + 1], "Letter")
+
+    def test_custom_geometry_and_duplex(self):
+        self.config.write_text("size=215.9x279.4\nresolution=600\nduplex=ON\n")
+        result = self.run_scan()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        args = self.calls("scanner")[0]
+        self.assertEqual(args[args.index("--size") + 1], "215.9x279.4")
+        self.assertEqual(args[args.index("--resolution") + 1], "600")
+        self.assertEqual(args.count("--source"), 1)
+        self.assertEqual(args[args.index("--source") + 1], "ADF_C")
+
+    def test_nonempty_failed_scan_is_not_converted(self):
+        result = self.run_scan(TEST_SCANNER_STATUS="7")
+        self.assert_failed(result, 7, "exit code 7")
+        self.assertEqual(len(self.calls("scanner")), 2)
+        self.assertEqual(self.calls("tiffcp"), [])
+        self.assertEqual(self.calls("mv"), [])
+
+    def test_empty_scan_is_failure_even_with_zero_exit(self):
+        result = self.run_scan(TEST_EMPTY_SCAN="1")
+        self.assert_failed(result, 1, "exit code 0")
+        self.assertEqual(self.calls("tiffcp"), [])
+
+    def test_compression_failure_is_logged_and_not_published(self):
+        result = self.run_scan(TEST_TIFFCP_STATUS="8")
+        self.assert_failed(result, 8, "compression failed with exit code 8")
+        self.assertEqual(self.calls("tiff2pdf"), [])
+
+    def test_pdf_failure_is_logged_and_not_published(self):
+        result = self.run_scan(TEST_TIFF2PDF_STATUS="9")
+        self.assert_failed(result, 9, "PDF conversion failed with exit code 9")
+        self.assertEqual(self.calls("mv"), [])
+
+    def test_empty_pdf_is_not_published(self):
+        result = self.run_scan(TEST_EMPTY_PDF="1")
+        self.assert_failed(result, 1, "output is empty")
+        self.assertEqual(self.calls("mv"), [])
+
+    def test_failed_move_keeps_completed_pdf_in_private_directory(self):
+        result = self.run_scan(TEST_MV_STATUS="18")
+        self.assert_failed(result, 18, "publication failed with exit code 18")
+        pdfs = list(self.staging.glob("job.*/scan.pdf"))
+        self.assertEqual(len(pdfs), 1)
+        self.assertEqual(pdfs[0].read_bytes(), b"%PDF-complete")
+        self.assertIn(str(pdfs[0]), result.stderr)
+        self.assertEqual(stat.S_IMODE(pdfs[0].parent.stat().st_mode), 0o700)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pkgsLinux/brscan-skey/tests.nix
+++ b/pkgsLinux/brscan-skey/tests.nix
@@ -1,0 +1,24 @@
+{
+  runCommand,
+  bash,
+  coreutils,
+  python3,
+  shellcheck,
+}:
+
+runCommand "brscan-skey-tests"
+  {
+    nativeBuildInputs = [
+      bash
+      coreutils
+      python3
+      shellcheck
+    ];
+  }
+  ''
+    cp ${./scantofile.sh} scantofile.sh
+    cp ${./test_scantofile.py} test_scantofile.py
+    shellcheck scantofile.sh
+    python3 test_scantofile.py
+    touch "$out"
+  ''


### PR DESCRIPTION
## Summary

- Publish completed Brother scans atomically into Paperless’s consumption directory.
- Add private staging, explicit failure logging, retry handling, and configurable paper size.
- Add shell/Python tests covering successful scans, geometry, conversion failures, and failed publication.
- Register the brscan-skey test derivation in flake checks.

## Testing

- Not run (not requested).