### PR TITLE
Add and package the Moshi hook daemon for Terminus

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -117,6 +117,7 @@
             builtins.elem (nixpkgs.lib.getName package) [
               "brscan-skey"
               "chatgpt"
+              "moshi-hook"
             ];
         }
       );

--- a/hosts/nixos/terminus/default.nix
+++ b/hosts/nixos/terminus/default.nix
@@ -33,6 +33,7 @@
     ./services/home-assistant
     ./services/ollama.nix
     ./services/brscan-skey.nix
+    ./services/moshi-hook.nix
     ./services/paperless.nix
     ./services/servarr
     ./services/samba.nix

--- a/hosts/nixos/terminus/services/moshi-hook.nix
+++ b/hosts/nixos/terminus/services/moshi-hook.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  username = config.hostSpec.username;
+in
+{
+  environment.systemPackages = [ pkgs.moshi-hook ];
+
+  # The common user module enables lingering, so default.target is reached at
+  # boot without waiting for an interactive login.
+  home-manager.users.${username}.systemd.user.services.moshi-hook = {
+    Unit = {
+      Description = "Moshi agent hook daemon";
+      Documentation = "https://getmoshi.app/docs/install-moshi-hook";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+    };
+
+    Service = {
+      ExecStart = "${lib.getExe pkgs.moshi-hook} serve";
+      Environment = "PATH=${
+        lib.makeBinPath [
+          pkgs.git
+          pkgs.herdr
+          pkgs.openssh
+          pkgs.tmux
+          pkgs.zellij
+        ]
+      }";
+      Restart = "on-failure";
+      RestartSec = 5;
+    };
+
+    Install.WantedBy = [ "default.target" ];
+  };
+}

--- a/pkgsLinux/default.nix
+++ b/pkgsLinux/default.nix
@@ -6,4 +6,5 @@
 {
   brscan-skey = pkgs.callPackage ./brscan-skey { };
   chatgpt = pkgs.callPackage ./chatgpt { };
+  moshi-hook = pkgs.callPackage ./moshi-hook { };
 }

--- a/pkgsLinux/moshi-hook/default.nix
+++ b/pkgsLinux/moshi-hook/default.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  coreutils,
+  curl,
+  git,
+  gnused,
+  nix,
+  writeShellApplication,
+}:
+
+let
+  version = "0.3.20";
+  x86_64Hash = "sha256-v7npl4Nj+ksZabIZuJmHn5V2u/oTCW/UbcGRB90zCWc=";
+  aarch64Hash = "sha256-D35dUHcJIn7aEWRVcSwa/PKxRZhCxjFe/6zKR4JhTXA=";
+
+  platform =
+    {
+      x86_64-linux = {
+        assetArch = "x86_64";
+        hash = x86_64Hash;
+      };
+      aarch64-linux = {
+        assetArch = "arm64";
+        hash = aarch64Hash;
+      };
+    }
+    .${stdenv.hostPlatform.system};
+
+  updateScript = writeShellApplication {
+    name = "update-moshi-hook";
+    runtimeInputs = [
+      coreutils
+      curl
+      git
+      gnused
+      nix
+    ];
+    text = builtins.readFile ./update.sh;
+  };
+in
+stdenv.mkDerivation {
+  pname = "moshi-hook";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://cdn.getmoshi.app/hook/v${version}/moshi-hook_Linux_${platform.assetArch}.tar.gz";
+    inherit (platform) hash;
+  };
+
+  sourceRoot = ".";
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 moshi-hook "$out/bin/moshi-hook"
+    ln -s moshi-hook "$out/bin/moshi"
+    mkdir -p "$out/share/doc/moshi-hook"
+    cp -r README.md docs "$out/share/doc/moshi-hook"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = [
+    (lib.getExe updateScript)
+    "pkgsLinux/moshi-hook/default.nix"
+  ];
+
+  meta = {
+    description = "Daemon and CLI bridging coding agents to the Moshi app";
+    homepage = "https://getmoshi.app";
+    license = lib.licenses.unfree;
+    mainProgram = "moshi-hook";
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/pkgsLinux/moshi-hook/update.sh
+++ b/pkgsLinux/moshi-hook/update.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils curl git gnused nix
+# shellcheck shell=bash
+
+set -euo pipefail
+
+cdn="https://cdn.getmoshi.app"
+package_path="${1:?package path is required}"
+version="$(curl --fail --location --silent --show-error "$cdn/hook/latest/version.txt")"
+version="${version//[[:space:]]/}"
+
+if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  printf 'unexpected moshi-hook version: %q\n' "$version" >&2
+  exit 1
+fi
+
+checksums="$(curl --fail --location --silent --show-error "$cdn/hook/$version/checksums.txt")"
+
+hash_for() {
+  local asset="$1"
+  local hash
+
+  hash="$(awk -v asset="$asset" '$2 == asset { print $1 }' <<< "$checksums")"
+  if [[ ! "$hash" =~ ^[0-9a-f]{64}$ ]]; then
+    printf 'missing or invalid checksum for %s\n' "$asset" >&2
+    exit 1
+  fi
+
+  nix hash convert --hash-algo sha256 --to sri "$hash"
+}
+
+x86_64_hash="$(hash_for moshi-hook_Linux_x86_64.tar.gz)"
+aarch64_hash="$(hash_for moshi-hook_Linux_arm64.tar.gz)"
+repo_root="$(git rev-parse --show-toplevel)"
+package_file="$repo_root/$package_path"
+
+sed --in-place --regexp-extended \
+  --expression="s|^([[:space:]]*version = )\"[^\"]+\";|\1\"${version#v}\";|" \
+  --expression="s|^([[:space:]]*x86_64Hash = )\"sha256-[^\"]+\";|\1\"$x86_64_hash\";|" \
+  --expression="s|^([[:space:]]*aarch64Hash = )\"sha256-[^\"]+\";|\1\"$aarch64_hash\";|" \
+  "$package_file"
+
+printf 'moshi-hook: updated to %s\n' "${version#v}"


### PR DESCRIPTION
## Summary

- Package the Linux Moshi hook binary for x86_64 and aarch64.
- Add a guarded update script for versions and platform hashes.
- Install and run Moshi hook as a lingering user service on Terminus.
- Expose the package through the system package allowlist.

## Testing

- Not run (not requested)